### PR TITLE
feat: Implement fetching all posts, pagination, and fixes

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -42,14 +42,48 @@ document.querySelectorAll('.content').forEach(contentEl => {
         preview.href = link.href;
         preview.target = '_blank';
         preview.rel = 'noopener noreferrer';
-        preview.innerHTML = `
-            <img class="link-preview-thumb" src="https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link.href)}" alt="icon">
-            <div class="link-preview-content">
-                <div class="link-preview-title">${link.href}</div>
-                <div class="link-preview-desc">正在加载预览…</div>
-                <div class="link-preview-domain">${(new URL(link.href)).hostname}</div>
-            </div>
-        `;
+
+        // Clear any existing content in preview (though it's a new element, good practice)
+        preview.innerHTML = ''; 
+
+        // Create image element
+        const img = document.createElement('img');
+        img.className = 'link-preview-thumb';
+        img.src = `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link.href)}`;
+        img.alt = 'icon';
+
+        // Create content container
+        const contentDiv = document.createElement('div');
+        contentDiv.className = 'link-preview-content';
+
+        // Create title element
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'link-preview-title';
+        titleDiv.textContent = link.href; // Use textContent
+
+        // Create description element
+        const descDiv = document.createElement('div');
+        descDiv.className = 'link-preview-desc';
+        descDiv.textContent = '正在加载预览…';
+
+        // Create domain element
+        const domainDiv = document.createElement('div');
+        domainDiv.className = 'link-preview-domain';
+        // Make sure link.href is a valid URL before trying to get hostname
+        try {
+            domainDiv.textContent = (new URL(link.href)).hostname; // Use textContent
+        } catch (e) {
+            domainDiv.textContent = link.href; // Fallback if URL parsing fails
+        }
+        
+        // Append elements
+        contentDiv.appendChild(titleDiv);
+        contentDiv.appendChild(descDiv);
+        contentDiv.appendChild(domainDiv);
+
+        preview.appendChild(img);
+        preview.appendChild(contentDiv);
+        
         link.parentNode.insertBefore(preview, link.nextSibling);
         fetch(`https://jsonlink.io/api/extract?url=${encodeURIComponent(link.href)}`)
         .then(res => res.json())

--- a/config.php
+++ b/config.php
@@ -5,10 +5,10 @@
 return [
     // Telegram频道短链接名称（不含 @）
     'channel' => 'biggestseahome',
-    // 抓取消息数量
-    'limit'   => 20,
     // 缓存目录（需可写）
     'cache_dir' => __DIR__ . '/cache',
     // 缓存有效期，单位秒
     'cache_ttl' => 300,
+    // 每页显示的文章数量
+    'posts_per_page' => 20,
 ];

--- a/fetcher.php
+++ b/fetcher.php
@@ -4,13 +4,11 @@
  */
 class Fetcher {
     protected $channel;
-    protected $limit;
     protected $cacheDir;
     protected $cacheTtl;
 
     public function __construct(array $config) {
         $this->channel  = $config['channel'];
-        $this->limit    = $config['limit'];
         $this->cacheDir = $config['cache_dir'];
         $this->cacheTtl = $config['cache_ttl'];
 
@@ -25,64 +23,154 @@ class Fetcher {
             return json_decode(file_get_contents($cacheFile), true);
         }
 
-        $url = "https://t.me/s/{$this->channel}";
-        $html = file_get_contents($url);
-        $dom  = new DOMDocument();
-        @$dom->loadHTML($html);
+        $allPosts = [];
+        $processedMessageIds = [];
+        $currentUrl = "https://t.me/s/{$this->channel}";
+        $description = '暂无简介'; // Default description
+        $maxPagesToFetch = 100; // Safety break for the loop
+        $pagesFetched = 0;
+
+        // Fetch description from the first page
+        $initialHtmlContent = file_get_contents($currentUrl);
+        if ($initialHtmlContent === false || empty($initialHtmlContent)) {
+            error_log("Fetcher: Failed to fetch initial page for channel {$this->channel} from URL: $currentUrl");
+            return ['description' => $description, 'messages' => []];
+        }
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        if (!$dom->loadHTML($initialHtmlContent)) {
+            error_log("Fetcher: Failed to parse HTML for initial page of channel {$this->channel}");
+            libxml_clear_errors();
+            return ['description' => $description, 'messages' => []];
+        }
+        libxml_clear_errors();
         $xpath = new DOMXPath($dom);
-
-        // 获取频道简介
         $descriptionNode = $xpath->query('//div[contains(@class, "tgme_channel_info_description")]')->item(0);
-        $description = $descriptionNode ? trim($descriptionNode->textContent) : '暂无简介';
+        if ($descriptionNode) {
+            $description = trim($descriptionNode->textContent);
+        }
 
-        $messages = [];
-        $items = $xpath->query('//div[contains(@class, "tgme_widget_message_wrap")]');
-        foreach ($items as $i => $node) {
-            if ($i >= $this->limit) break;
-            // 时间
-            $timeNode = $xpath->query('.//time', $node)->item(0);
-            $time = $timeNode ? $timeNode->getAttribute('datetime') : '';
-            // 文本内容，保留HTML结构
-            $textNode = $xpath->query('.//div[contains(@class, "tgme_widget_message_text")]', $node)->item(0);
-            $text = '';
-            if ($textNode) {
-                $innerHTML = '';
-                foreach ($textNode->childNodes as $child) {
-                    $innerHTML .= $textNode->ownerDocument->saveHTML($child);
-                }
-                $text = trim($innerHTML);
+
+        while ($currentUrl && $pagesFetched < $maxPagesToFetch) {
+            $pagesFetched++;
+            // Use $initialHtmlContent for the first iteration, then fetch subsequent pages
+            $html = ($pagesFetched === 1) ? $initialHtmlContent : file_get_contents($currentUrl);
+            
+            // Clear $initialHtmlContent after its first use to ensure fresh fetches for subsequent pages
+            if ($pagesFetched === 1) {
+                unset($initialHtmlContent);
             }
-            // 查看人数
-            $viewNode = $xpath->query('.//span[contains(@class, "tgme_widget_message_views")]', $node)->item(0);
-            $views = $viewNode ? trim($viewNode->textContent) : '0';
-            // 图片
+
+            if ($html === false || empty($html)) {
+                error_log("Fetcher: Failed to fetch HTML from $currentUrl for channel {$this->channel} (Page: $pagesFetched)");
+                break; // Stop if fetching fails
+            }
+
+            $dom = new DOMDocument();
+            // Use internal errors to avoid outputting HTML parsing errors
+            libxml_use_internal_errors(true);
+            if (!$dom->loadHTML($html)) {
+                error_log("Fetcher: Failed to parse HTML from $currentUrl for channel {$this->channel}");
+                libxml_clear_errors();
+                break; 
+            }
+            libxml_clear_errors();
+            $xpath = new DOMXPath($dom);
+
+            $messageNodes = $xpath->query('//div[contains(@class, "tgme_widget_message_wrap")]');
             
-            // 图片，改为提取所有图片
-            $imgWraps = $xpath->query('.//a[contains(@class, "tgme_widget_message_photo_wrap")]', $node);
-            $imgs = [];
-            foreach ($imgWraps as $imgWrap) {
-                $style = $imgWrap->getAttribute('style');
-                if (preg_match('/url\(([^)]+)\)/', $style, $m)) {
-                    $rawUrl = trim($m[1], "'\"");
-                    $img = strpos($rawUrl, '//') === 0 ? 'https:' . $rawUrl : $rawUrl;
-                    $imgs[] = $img;
+            if ($messageNodes->length === 0) {
+                // No more messages found on this page
+                break;
+            }
+
+            $newMessagesOnPage = 0;
+            $lastProcessedMessageIdOnPage = null;
+
+            foreach ($messageNodes as $node) {
+                $messageLinkNode = $xpath->query('.//a[contains(@class, "tgme_widget_message_date")]', $node)->item(0);
+                $messageId = null;
+                if ($messageLinkNode) {
+                    $linkHref = $messageLinkNode->getAttribute('href');
+                    if (preg_match('/\/(\d+)$/', $linkHref, $matches)) {
+                        $messageId = $matches[1];
+                    }
                 }
+                
+                // Fallback or alternative: Try to get data-post attribute from the message div itself
+                if (!$messageId) {
+                    $messageDataPost = $node->getAttribute('data-post');
+                    if ($messageDataPost && strpos($messageDataPost, '/') !== false) {
+                         list(,$messageId) = explode('/', $messageDataPost);
+                    }
+                }
+
+
+                if ($messageId && !in_array($messageId, $processedMessageIds)) {
+                    $processedMessageIds[] = $messageId;
+                    $newMessagesOnPage++;
+
+                    $timeNode = $xpath->query('.//time', $node)->item(0);
+                    $time = $timeNode ? $timeNode->getAttribute('datetime') : '';
+                    
+                    $textNode = $xpath->query('.//div[contains(@class, "tgme_widget_message_text")]', $node)->item(0);
+                    $text = '';
+                    if ($textNode) {
+                        $innerHTML = '';
+                        foreach ($textNode->childNodes as $child) {
+                            $innerHTML .= $textNode->ownerDocument->saveHTML($child);
+                        }
+                        $text = trim($innerHTML);
+                    }
+                    
+                    $viewNode = $xpath->query('.//span[contains(@class, "tgme_widget_message_views")]', $node)->item(0);
+                    $views = $viewNode ? trim($viewNode->textContent) : '0';
+                    
+                    $imgWraps = $xpath->query('.//a[contains(@class, "tgme_widget_message_photo_wrap")]', $node);
+                    $imgs = [];
+                    foreach ($imgWraps as $imgWrap) {
+                        $style = $imgWrap->getAttribute('style');
+                        if (preg_match('/url\(([^)]+)\)/', $style, $m)) {
+                            $rawUrl = trim($m[1], "'\"");
+                            $img = strpos($rawUrl, '//') === 0 ? 'https:' . $rawUrl : $rawUrl;
+                            $imgs[] = $img;
+                        }
+                    }
+                    
+                    $allPosts[] = [
+                        'id' => $messageId, // Store ID for reference
+                        'time' => $time,
+                        'text' => $text,
+                        'views'=> $views,
+                        'imgs' => $imgs,
+                    ];
+                    $lastProcessedMessageIdOnPage = $messageId;
+                } elseif ($messageId && in_array($messageId, $processedMessageIds)) {
+                    // This message was already processed, likely from an overlapping page load.
+                    // Continue to check other messages on this page.
+                }
+                 // If no messageId, it's an issue with parsing that specific message, skip it.
+            }
+
+            if ($newMessagesOnPage === 0 && $messageNodes->length > 0) {
+                // Fetched a page, but all messages on it were already processed.
+                // This means we've reached the end of unique new content.
+                break;
             }
             
-            $messages[] = [
-                'time' => $time,
-                'text' => $text,
-                'views'=> $views,
-                'imgs' => $imgs,
-            ];
-
-
-            
+            if ($lastProcessedMessageIdOnPage !== null) {
+                $currentUrl = "https://t.me/s/{$this->channel}?before={$lastProcessedMessageIdOnPage}";
+                sleep(1); // Be polite to the server
+            } else {
+                // Could not determine the next page URL (e.g., no new messages found, or couldn't extract ID)
+                $currentUrl = null;
+            }
         }
 
         $data = [
             'description' => $description,
-            'messages' => array_reverse($messages)
+            'messages' => array_reverse($allPosts) // Reverse to keep chronological order (newest first in t.me/s)
         ];
 
         file_put_contents($cacheFile, json_encode($data));


### PR DESCRIPTION
This commit introduces several major enhancements and fixes:

1.  **Fetch All Posts:**
    - Modified `fetcher.php` to iteratively fetch all posts from a Telegram channel by following the "?before=<message_id>" pagination mechanism.
    - Removed the previous hard limit on the number of posts fetched.
    - Added error handling and logging for fetching and parsing processes.
    - Included a small delay between fetches to be polite to the server.

2.  **Pagination:**
    - Implemented backend pagination logic in `index.php`.
    - Added `posts_per_page` configuration to `config.php`.
    - Implemented a comprehensive frontend pagination UI in `index.php`, including "Previous/Next" links and smart page number display (with ellipses for many pages).

3.  **Security & Bug Fixes:**
    - Hardened link preview generation in `assets/script.js` by using `textContent` instead of `innerHTML` to reduce XSS risk.
    - Ensured `fetcher.php` has robust error handling for network issues or parsing failures.

4.  **Code Structure:**
    - `fetcher.php`: Now includes message IDs in the returned data.
    - `config.php`: Removed obsolete `limit` setting, added `posts_per_page`.
    - `index.php`: Adapted to use paginated data.

A recommendation for securing the visitor counter's cache directory (preventing direct web access to .txt files and directory listing) has also been noted.