### PR TITLE
修复bug:部分图片在手机端打开时确保灯箱导航箭头可见且位置正确

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -147,6 +147,24 @@ document.querySelectorAll('.content').forEach(contentEl => {
             lightboxImg.src = currentSet[currentIdx];
             lightboxImg.classList.add('fade-in');
             lightboxIndex.textContent = (currentIdx+1) + ' / ' + currentSet.length;
+
+            // Conditionally show/hide navigation arrows
+            if (currentSet.length <= 1) {
+                lightboxPrev.style.display = 'none';
+                lightboxNext.style.display = 'none';
+            } else {
+                if (currentIdx === 0) {
+                    lightboxPrev.style.display = 'none';
+                } else {
+                    lightboxPrev.style.display = 'flex';
+                }
+
+                if (currentIdx === currentSet.length - 1) {
+                    lightboxNext.style.display = 'none';
+                } else {
+                    lightboxNext.style.display = 'flex';
+                }
+            }
         }, 10);
     }
     function prevImg(){

--- a/assets/style.css
+++ b/assets/style.css
@@ -455,11 +455,11 @@ body {
 }
 
 .lightbox-prev {
-    left: -54px;
+    left: 15px; /* Position arrow inside content box */
 }
 
 .lightbox-next {
-    right: -54px;
+    right: 15px; /* Position arrow inside content box */
 }
 
 .lightbox-index {
@@ -500,10 +500,9 @@ body {
     .lightbox-next {
         font-size: 1.5em;
     }
-    .lightbox-prev {
-        left: -36px;
-    }
-    .lightbox-next {
-        right: -36px;
-    }
+    /* Removed mobile-specific negative horizontal positioning for arrows.
+       The new desktop rules (left: 15px, right: 15px) will apply.
+       Vertical centering is handled by the main rule for .lightbox-prev, .lightbox-next. */
+    /* .lightbox-prev { left: 5px; } /* Example if finer mobile adjustment was needed */
+    /* .lightbox-next { right: 5px; } /* Example if finer mobile adjustment was needed */
 }


### PR DESCRIPTION
修复：确保灯箱导航箭头可见且位置正确

图片灯箱中的上一个和下一个导航箭头有时会显示缺失，尤其是在移动设备上。这主要有两个原因：
1. CSS 定位将箭头置于灯箱主内容区域之外，导致它们在较窄的视口下被推到屏幕外。
2. 箭头始终显示，即使是单张图片或图库边界（第一张/最后一张图片）。

此提交通过以下方式解决了这些问题：
- 修改 `assets/script.js`：
- `updateLightbox` 函数现在可以有条件地显示/隐藏上一个和下一个箭头。
- 如果只有一张图片，则箭头会被隐藏。
- 图库第一张图片上的“上一个”箭头会被隐藏。
- 图库最后一张图片上的“下一个”箭头会被隐藏。
- 修改 `assets/style.css`：
- 修改了 `.lightbox-prev` 和 `.lightbox-next` 的 CSS 规则，使用正 `left` 和 `right` 值（例如 `15px`）将它们定位在 `lightbox-content` 区域内。
- 移除了特定于移动设备的负偏移规则，以便一致地应用新的默认定位。

这些更改确保箭头仅在可导航时显示，并且始终在桌面设备和移动设备的灯箱边界内可见。