### PR TITLE
Add files via upload

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -29,80 +29,105 @@ document.querySelectorAll('.tag').forEach(tag => {
 // Client-side filtering and back button logic previously here are now removed,
 // as filtering is handled by the backend and navigation is via direct links.
 
-// --- 生成链接预览框 ---
-document.querySelectorAll('.content').forEach(contentEl => {
-    contentEl.querySelectorAll('.external-link').forEach(link => {
+// --- 生成链接预览框（可见时再加载，限制并发与超时） ---
+(function(){
+    const VISIBILITY_MARGIN = '200px';
+    const MAX_CONCURRENCY = 2;
+    const FETCH_TIMEOUT = 4500; // ms
+
+    const tasks = [];
+    let inflight = 0;
+
+    function runQueue(){
+        while (inflight < MAX_CONCURRENCY && tasks.length) {
+            const fn = tasks.shift();
+            inflight++;
+            Promise.resolve().then(fn).finally(()=>{ inflight--; runQueue(); });
+        }
+    }
+
+    function enqueue(fn){
+        tasks.push(fn);
+        runQueue();
+    }
+
+    function fetchWithTimeout(url, opts = {}, timeout = FETCH_TIMEOUT){
+        if (typeof AbortController === 'undefined') {
+            return fetch(url, opts);
+        }
+        const ctl = new AbortController();
+        const id = setTimeout(()=>ctl.abort(), timeout);
+        return fetch(url, { ...opts, signal: ctl.signal }).finally(()=>clearTimeout(id));
+    }
+
+    function ensurePreview(link){
         if (link.dataset.hasPreview) return;
-        link.dataset.hasPreview = "1";
+        link.dataset.hasPreview = '1';
         if (!/^https?:\/\//.test(link.href)) return;
+
         const preview = document.createElement('a');
         preview.className = 'link-preview';
         preview.href = link.href;
         preview.target = '_blank';
         preview.rel = 'noopener noreferrer';
 
-        // Clear any existing content in preview (though it's a new element, good practice)
-        preview.innerHTML = ''; 
-
-        // Create image element
+        // 构建骨架
         const img = document.createElement('img');
         img.className = 'link-preview-thumb';
-        img.src = `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link.href)}`;
         img.alt = 'icon';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        img.src = `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link.href)}`;
 
-        // Create content container
         const contentDiv = document.createElement('div');
         contentDiv.className = 'link-preview-content';
-
-        // Create title element
         const titleDiv = document.createElement('div');
         titleDiv.className = 'link-preview-title';
-        titleDiv.textContent = link.href; // Use textContent
-
-        // Create description element
+        titleDiv.textContent = link.href;
         const descDiv = document.createElement('div');
         descDiv.className = 'link-preview-desc';
         descDiv.textContent = '正在加载预览…';
-
-        // Create domain element
         const domainDiv = document.createElement('div');
         domainDiv.className = 'link-preview-domain';
-        // Make sure link.href is a valid URL before trying to get hostname
-        try {
-            domainDiv.textContent = (new URL(link.href)).hostname; // Use textContent
-        } catch (e) {
-            domainDiv.textContent = link.href; // Fallback if URL parsing fails
-        }
-        
-        // Append elements
+        try { domainDiv.textContent = (new URL(link.href)).hostname; } catch(e) { domainDiv.textContent = link.href; }
+
         contentDiv.appendChild(titleDiv);
         contentDiv.appendChild(descDiv);
         contentDiv.appendChild(domainDiv);
-
         preview.appendChild(img);
         preview.appendChild(contentDiv);
-        
         link.parentNode.insertBefore(preview, link.nextSibling);
-        fetch(`https://jsonlink.io/api/extract?url=${encodeURIComponent(link.href)}`)
-        .then(res => res.json())
-        .then(data => {
-            if (data.title) {
-                preview.querySelector('.link-preview-title').textContent = data.title;
-            }
-            if (data.description) {
-                preview.querySelector('.link-preview-desc').textContent = data.description;
-            } else {
-                preview.querySelector('.link-preview-desc').textContent = '';
-            }
-            if (data.images && data.images.length > 0) {
-                preview.querySelector('.link-preview-thumb').src = data.images[0];
-            }
-        })
-        .catch(() => {
-            preview.querySelector('.link-preview-desc').textContent = '';
-        });
-    });
-});
+
+        enqueue(() => fetchWithTimeout(`https://jsonlink.io/api/extract?url=${encodeURIComponent(link.href)}`)
+            .then(res => res.ok ? res.json() : Promise.reject())
+            .then(data => {
+                if (!preview.isConnected) return;
+                if (data.title) titleDiv.textContent = data.title;
+                descDiv.textContent = data.description ? data.description : '';
+                if (data.images && data.images.length > 0) {
+                    img.src = data.images[0];
+                }
+            })
+            .catch(() => { if (preview.isConnected) { descDiv.textContent = ''; } })
+        );
+    }
+
+    const containerLinks = Array.from(document.querySelectorAll('.content .external-link'));
+    if ('IntersectionObserver' in window) {
+        const io = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    ensurePreview(entry.target);
+                    io.unobserve(entry.target);
+                }
+            });
+        }, { root: null, rootMargin: VISIBILITY_MARGIN, threshold: 0.01 });
+        containerLinks.forEach(link => io.observe(link));
+    } else {
+        // 兼容不支持 IO 的环境：一次性生成
+        containerLinks.forEach(ensurePreview);
+    }
+})();
 // --------- 图片灯箱和多图浏览 ----------
 (function(){
     // 灯箱元素

--- a/config.php
+++ b/config.php
@@ -7,10 +7,14 @@ return [
     'channel' => 'biggestseahome',
     // 缓存目录（需可写）
     'cache_dir' => __DIR__ . '/cache',
-    // 缓存有效期，单位秒
-    'cache_ttl' => 300,
+    // 缓存有效期，单位秒（适当延长，降低抓取频率）
+    'cache_ttl' => 1800,
     // 每页显示的文章数量
     'posts_per_page' => 20,
     // 标签过滤时，扫描的最大文章数量
-    'tag_filter_max_posts_to_scan' => 400,
+    'tag_filter_max_posts_to_scan' => 100,
+    // 抓取最大帖子数量（限制深翻页，避免过慢）
+    'max_posts_to_collect' => 200,
+    // 过期可用 + 后台刷新（SWR）保护间隔（秒），避免并发重复刷新
+    'swr_refresh_min_interval' => 60,
 ];

--- a/fetcher.php
+++ b/fetcher.php
@@ -6,11 +6,15 @@ class Fetcher {
     protected $channel;
     protected $cacheDir;
     protected $cacheTtl;
+    protected $maxPosts;
+    protected $swrMinInterval;
 
     public function __construct(array $config) {
         $this->channel  = $config['channel'];
         $this->cacheDir = $config['cache_dir'];
         $this->cacheTtl = $config['cache_ttl'];
+        $this->maxPosts = $config['max_posts_to_collect'] ?? 200;
+        $this->swrMinInterval = $config['swr_refresh_min_interval'] ?? 60;
 
         if (!is_dir($this->cacheDir)) {
             mkdir($this->cacheDir, 0755, true);
@@ -19,19 +23,85 @@ class Fetcher {
 
     public function getPosts() {
         $cacheFile = "$this->cacheDir/{$this->channel}.json";
+        // 命中未过期缓存直接返回
         if (file_exists($cacheFile) && time() - filemtime($cacheFile) < $this->cacheTtl) {
-            return json_decode(file_get_contents($cacheFile), true);
+            return json_decode(@file_get_contents($cacheFile) ?: '[]', true);
         }
 
+        // 过期缓存：SWR，先返回旧缓存，后台刷新
+        if (file_exists($cacheFile)) {
+            $stale = json_decode(@file_get_contents($cacheFile) ?: '[]', true);
+            $this->scheduleBackgroundRefresh($cacheFile);
+            return $stale ?: ['description' => '暂无简介', 'messages' => []];
+        }
+
+        // 没有缓存，则立即刷新（带超时与重试）
+        return $this->refreshNow($cacheFile);
+    }
+
+    protected function scheduleBackgroundRefresh(string $cacheFile): void {
+        $lock = $this->cacheDir . '/refresh_' . $this->channel . '.lock';
+        $now = time();
+        $canRefresh = true;
+        if (file_exists($lock)) {
+            $last = (int)@file_get_contents($lock);
+            if ($last && ($now - $last) < $this->swrMinInterval) {
+                $canRefresh = false;
+            }
+        }
+        if (!$canRefresh) return;
+        @file_put_contents($lock, (string)$now, LOCK_EX);
+
+        register_shutdown_function(function() use ($cacheFile, $lock) {
+            if (function_exists('fastcgi_finish_request')) {
+                @fastcgi_finish_request();
+            }
+            try {
+                $this->refreshNow($cacheFile);
+            } finally {
+                @file_put_contents($lock, (string)time(), LOCK_EX);
+            }
+        });
+    }
+
+    protected function httpGet(string $url, int $timeout = 8) {
+        $ctx = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => $timeout,
+                'header' => "User-Agent: Mozilla/5.0 (Fetcher; +https://note.biggestsea.top)\r\nAccept: text/html,application/xhtml+xml\r\n",
+            ],
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
+        ]);
+        return @file_get_contents($url, false, $ctx);
+    }
+
+    protected function httpGetWithRetry(string $url, int $retries = 2, int $timeout = 8) {
+        $attempt = 0;
+        $delay = 300; // ms 指数退避
+        while (true) {
+            $attempt++;
+            $res = $this->httpGet($url, $timeout);
+            if ($res !== false && $res !== '') return $res;
+            if ($attempt > $retries) return false;
+            usleep($delay * 1000);
+            $delay = min($delay * 2, 1500);
+        }
+    }
+
+    protected function refreshNow(string $cacheFile) {
         $allPosts = [];
         $processedMessageIds = [];
         $currentUrl = "https://t.me/s/{$this->channel}";
-        $description = '暂无简介'; // Default description
-        $maxPagesToFetch = 100; // Safety break for the loop
+        $description = '暂无简介';
+        $maxPagesToFetch = 50; // 安全上限
         $pagesFetched = 0;
 
-        // Fetch description from the first page
-        $initialHtmlContent = file_get_contents($currentUrl);
+        // 首次页面
+        $initialHtmlContent = $this->httpGetWithRetry($currentUrl, 2, 8);
         if ($initialHtmlContent === false || empty($initialHtmlContent)) {
             error_log("Fetcher: Failed to fetch initial page for channel {$this->channel} from URL: $currentUrl");
             return ['description' => $description, 'messages' => []];
@@ -54,10 +124,9 @@ class Fetcher {
 
         while ($currentUrl && $pagesFetched < $maxPagesToFetch) {
             $pagesFetched++;
-            // Use $initialHtmlContent for the first iteration, then fetch subsequent pages
-            $html = ($pagesFetched === 1) ? $initialHtmlContent : file_get_contents($currentUrl);
+            // 首次使用 initial，之后重试抓取
+            $html = ($pagesFetched === 1) ? $initialHtmlContent : $this->httpGetWithRetry($currentUrl, 2, 8);
             
-            // Clear $initialHtmlContent after its first use to ensure fresh fetches for subsequent pages
             if ($pagesFetched === 1) {
                 unset($initialHtmlContent);
             }
@@ -68,7 +137,6 @@ class Fetcher {
             }
 
             $dom = new DOMDocument();
-            // Use internal errors to avoid outputting HTML parsing errors
             libxml_use_internal_errors(true);
             if (!$dom->loadHTML($html)) {
                 error_log("Fetcher: Failed to parse HTML from $currentUrl for channel {$this->channel}");
@@ -81,7 +149,6 @@ class Fetcher {
             $messageNodes = $xpath->query('//div[contains(@class, "tgme_widget_message_wrap")]');
             
             if ($messageNodes->length === 0) {
-                // No more messages found on this page
                 break;
             }
 
@@ -157,31 +224,32 @@ class Fetcher {
                     $processedMessageIds[] = $messageData['id'];
                     $allPosts[] = $messageData; // Add the full pre-prepared message data
                     $newMessagesOnPage++;
-                    $lastProcessedMessageIdOnPage = $messageData['id']; // This will be the oldest ID in this batch
+                    $lastProcessedMessageIdOnPage = $messageData['id'];
+                    if (count($allPosts) >= $this->maxPosts) {
+                        $currentUrl = null;
+                        break;
+                    }
                 }
             }
 
-            if ($newMessagesOnPage === 0 && !empty($currentPageMessages)) { // Changed condition slightly
-                // Fetched a page, but all messages on it were already processed.
-                // This means we've reached the end of unique new content.
+            if ($newMessagesOnPage === 0 && !empty($currentPageMessages)) {
                 break;
             }
             
             if ($lastProcessedMessageIdOnPage !== null) {
                 $currentUrl = "https://t.me/s/{$this->channel}?before={$lastProcessedMessageIdOnPage}";
-                sleep(1); // Be polite to the server
+                usleep(300000); // 300ms 礼貌延迟
             } else {
-                // Could not determine the next page URL (e.g., no new messages found, or couldn't extract ID)
                 $currentUrl = null;
             }
         }
 
         $data = [
             'description' => $description,
-            'messages' => $allPosts // Keep the natural order: newest posts (first page) first
+            'messages' => $allPosts
         ];
 
-        file_put_contents($cacheFile, json_encode($data));
+        @file_put_contents($cacheFile, json_encode($data));
         return $data;
     }
 }

--- a/index.php
+++ b/index.php
@@ -96,10 +96,18 @@ file_put_contents($statFile, $visits);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($page_title); ?></title>
     <link rel="stylesheet" href="assets/style.css">
+    <link rel="dns-prefetch" href="//t.me">
+    <link rel="preconnect" href="https://t.me" crossorigin>
+    <link rel="dns-prefetch" href="//cdn5.telesco.pe">
+    <link rel="preconnect" href="https://cdn5.telesco.pe" crossorigin>
+    <link rel="dns-prefetch" href="//jsonlink.io">
+    <link rel="preconnect" href="https://jsonlink.io" crossorigin>
+    <link rel="dns-prefetch" href="//www.google.com">
+    <link rel="preconnect" href="https://www.google.com" crossorigin>
 </head>
 <body>
 <div class="topbar">
-    <img src="https://t.me/i/userpic/320/<?php echo $channelName; ?>.jpg" alt="头像" class="avatar">
+    <img src="https://t.me/i/userpic/320/<?php echo $channelName; ?>.jpg" alt="头像" class="avatar" loading="lazy" decoding="async">
     <div class="channel-info">
         <a href="/" style="text-decoration: none; color: inherit;"><h1>@<?php echo htmlspecialchars($channelName); ?></h1></a>
         <p><?php echo htmlspecialchars($description); ?></p>
@@ -132,7 +140,7 @@ file_put_contents($statFile, $visits);
                 <?php if (!empty($post['imgs'])): ?>
                     <div class="image-gallery">
                         <?php foreach ($post['imgs'] as $idx => $img): ?>
-                            <img src="<?php echo htmlspecialchars($img); ?>" alt="" class="adaptive-img" data-idx="<?php echo $idx; ?>">
+                            <img src="<?php echo htmlspecialchars($img); ?>" alt="" class="adaptive-img" data-idx="<?php echo $idx; ?>" loading="lazy" decoding="async" referrerpolicy="no-referrer">
                         <?php endforeach; ?>
                     </div>
                 <?php endif; ?>
@@ -247,4 +255,9 @@ file_put_contents($statFile, $visits);
 <script src="assets/script.js"></script>
 </body>
 </html>
-
+<?php
+// 若存在后台刷新任务，确保尽快结束响应
+if (function_exists('fastcgi_finish_request')) {
+    @fastcgi_finish_request();
+}
+?>


### PR DESCRIPTION
已做的改动
- 后端缓存与抓取
  - 延长缓存：`config.php` 将 `cache_ttl` 提升为 `1800` 秒。
  - SWR模式：有过期缓存时，优先返回旧缓存，并在请求结束后后台刷新（带锁防并发
）
。实现文件：`fetcher.php`
  - 网络健壮性：为抓取增加 UA、超时（8s）、重试（指数退避），减少阻塞首字节的情
况。
  - 限制深翻页：新增 `max_posts_to_collect`（默认200），减少不必要的翻页抓取。
  - 更温和延迟：分页抓取间隔由 `sleep(1)` 改为 `usleep(300ms)`，提升后台刷新速度
同时不激进。
- 图片懒加载（UI不变）
  - 头像与文章图片添加 `loading="lazy" decoding="async"`，减少首屏负载。实现文
件
：`index.php`
  - 对外链图片增加 `referrerpolicy="no-referrer"`，降低被防盗链影响的概率（不改U
I）。
- 外链预览懒加载与限流（UI不变）
  - 仅当链接进入视口时，才请求 `jsonlink.io`，并发数限制为2，请求超时4.5s自动中
止（保持交互流畅）。实现文件：`assets/script.js`
- 连接预热（UI不变）
  - 在 `<head>` 加入 `dns-prefetch` / `preconnect` 到 `t.me`、`telesco.pe`、`jso
nlink.io`、`www.google.com`，降低DNS/TLS时延。实现文件：`index.php`
- 快速结束响应
  - 页面输出后调用 `fastcgi_finish_request()`（若可用），确保后台刷新不阻塞客户
端。实现文件：`index.php`

关键文件与变更点
- `config.php`
  - `cache_ttl`=1800
  - 新增 `max_posts_to_collect`=200, `swr_refresh_min_interval`=60
- `fetcher.php`
  - 新增 SWR 逻辑（过期→先返回旧缓存→注册后台刷新）
  - 增加 `httpGet`/`httpGetWithRetry`，抓取设置 UA/超时/重试
  - 控制最多采集帖子数，缩短分页延时至 300ms
- `index.php`
  - 头像/图片懒加载
  - 添加 `dns-prefetch`/`preconnect` 链接
  - 页尾安全调用 `fastcgi_finish_request()`
- `assets/script.js`
  - 使用 `IntersectionObserver` 可见时生成预览
  - 并发上限=2，超时=4.5s（`AbortController` 限时中止）

说明
- 以上均为“界面不变”的内部优化：不改变布局/样式/元素结构与数量，用户视觉与交互保
持一致。
- 首次无缓存时仍会进行同步抓取，但已加超时/重试与深度限制；之后多数请求命中缓存
或走SWR后台刷新，显著降低TTFB尖峰。
- 外链预览在未滚动到时不会发起请求；进入视口后再加载，视觉表现一致，只是更高效。

可调参数（如需微调）
- `cache_ttl`：1800 → 可调 3600（更少刷新频率）
- `swr_refresh_min_interval`：60 → 控制并发刷新频率
- `max_posts_to_collect`：200 → 控制抓取深度/速度
- 预览并发/超时：`MAX_CONCURRENCY=2`、`FETCH_TIMEOUT=4500`